### PR TITLE
feat: add legal notices page (mentions-legales) and integrate into layout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,84 @@
     "legal_notice": "Legal Notices",
     "copyright": "Copyright {currentYear}"
   },
+  "legalNotice": {
+    "title": "Legal Notices",
+    "lastUpdate": "Last update: January 2025",
+    "editor": {
+      "title": "1. Website Publisher",
+      "name": "Name:",
+      "address": "Address:",
+      "email": "Email:",
+      "siteType": "Website Type:",
+      "siteTypeValue": "Personal Portfolio - Non-commercial website"
+    },
+    "hosting": {
+      "title": "2. Web Hosting",
+      "provider": "Host:",
+      "address": "Address:",
+      "website": "Website:"
+    },
+    "intellectualProperty": {
+      "title": "3. Intellectual Property",
+      "content": "All content on this website (texts, images, source code, design) is the exclusive property of the publisher, unless explicitly stated otherwise.",
+      "copyright": "Any reproduction, distribution, modification, or use of content without prior authorization is strictly prohibited and may result in legal action."
+    },
+    "musicCredits": {
+      "title": "4. Music Credits - Halloween Page",
+      "intro": "The music excerpts used on the 'This is Halloween' page are copyrighted works belonging to their respective owners. They are used for educational, entertainment, and cultural promotion purposes:",
+      "addamsFamily": "The Addams Family - Theme composed by Vic Mizzy",
+      "americanHorrorStory": "American Horror Story - Theme by Cesar Davila-Irizarry and Charlie Clouser",
+      "coraline": "Coraline - Music by Bruno Coulais",
+      "corpseBride": "Corpse Bride - Music by Danny Elfman",
+      "scoobyDoo": "Scooby-Doo - Theme by David Mook and Ben Raleigh",
+      "exorcist": "The Exorcist - Tubular Bells by Mike Oldfield",
+      "ghostbusters": "Ghostbusters - Theme by Ray Parker Jr.",
+      "jaws": "Jaws - Theme by John Williams",
+      "lionKing": "The Lion King - 'Be Prepared' by Elton John and Tim Rice",
+      "ratched": "Ratched - Music by Mac Quayle",
+      "buffy": "Buffy the Vampire Slayer - Theme by Nerf Herder",
+      "scream": "Scream - Music by Marco Beltrami",
+      "strangerThings": "Stranger Things - Theme by Kyle Dixon and Michael Stein",
+      "littleMermaid": "The Little Mermaid - 'Poor Unfortunate Souls' by Alan Menken and Howard Ashman",
+      "thriller": "Thriller - Michael Jackson",
+      "walkingDead": "The Walking Dead - Theme by Bear McCreary",
+      "saw": "Saw - 'Hello Zepp' by Charlie Clouser",
+      "charmed": "Charmed - Theme by Love Spit Love",
+      "dexter": "Dexter - Theme by Rolfe Kent",
+      "thisIsHalloween": "This is Halloween - The Nightmare Before Christmas, music by Danny Elfman",
+      "fairUse": "These excerpts are used under fair use for educational and non-commercial purposes. Upon request from copyright holders, the relevant content will be immediately removed."
+    },
+    "privacy": {
+      "title": "5. Personal Data Protection (GDPR)",
+      "dataCollection": {
+        "title": "Data Collection",
+        "content": "This website currently does not collect any personal data. There is no contact form. The only means of communication is through the publicly displayed email address."
+      },
+      "cookies": {
+        "title": "Cookies",
+        "content": "This website currently does not use tracking or analytics cookies. Only technical cookies strictly necessary for the website's operation may be used."
+      },
+      "rights": {
+        "title": "Your Rights",
+        "content": "In accordance with the General Data Protection Regulation (GDPR), you have the right to access, rectify, delete, and port your data. To exercise these rights, contact us by email."
+      }
+    },
+    "liability": {
+      "title": "6. Limitation of Liability",
+      "content": "The publisher strives to keep the website information up-to-date and accurate but cannot guarantee the accuracy, precision, or completeness of the information. The publisher cannot be held responsible for errors, omissions, or results obtained from using this information."
+    },
+    "externalLinks": {
+      "title": "7. External Links",
+      "content": "This website may contain links to external sites. The publisher has no control over the content of these sites and disclaims all responsibility for their content or practices."
+    },
+    "applicableLaw": {
+      "title": "8. Applicable Law",
+      "content": "These legal notices are governed by French law. Any dispute relating to the use of this website will be subject to the exclusive jurisdiction of French courts."
+    }
+  },
   "halloween": {
+    "credits_notice": "Music excerpts are used for educational and non-commercial purposes. See",
+    "credits_link": "full credits",
     "music": {
       "adams_family": "The Addams Family",
       "american_horror_story": "American Horror Story",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,7 +15,84 @@
     "copyright": "Copyright {currentYear}",
     "legal_notice": "mentions légales"
   },
+  "legalNotice": {
+    "title": "Mentions Légales",
+    "lastUpdate": "Dernière mise à jour : Janvier 2025",
+    "editor": {
+      "title": "1. Éditeur du site",
+      "name": "Nom et Prénom :",
+      "address": "Adresse :",
+      "email": "Email :",
+      "siteType": "Type de site :",
+      "siteTypeValue": "Portfolio personnel - Site non commercial"
+    },
+    "hosting": {
+      "title": "2. Hébergement",
+      "provider": "Hébergeur :",
+      "address": "Adresse :",
+      "website": "Site web :"
+    },
+    "intellectualProperty": {
+      "title": "3. Propriété intellectuelle",
+      "content": "L'ensemble du contenu de ce site (textes, images, code source, design) est la propriété exclusive de l'éditeur, sauf mention contraire explicite.",
+      "copyright": "Toute reproduction, distribution, modification ou utilisation des contenus sans autorisation préalable est strictement interdite et peut faire l'objet de poursuites."
+    },
+    "musicCredits": {
+      "title": "4. Crédits musicaux - Page Halloween",
+      "intro": "Les extraits musicaux utilisés sur la page 'This is Halloween' sont des œuvres protégées par le droit d'auteur et appartiennent à leurs ayants droit respectifs. Ils sont utilisés à des fins pédagogiques, de divertissement et de promotion culturelle :",
+      "addamsFamily": "La Famille Addams - Thème composé par Vic Mizzy",
+      "americanHorrorStory": "American Horror Story - Thème par Cesar Davila-Irizarry et Charlie Clouser",
+      "coraline": "Coraline - Musique de Bruno Coulais",
+      "corpseBride": "Les Noces Funèbres - Musique de Danny Elfman",
+      "scoobyDoo": "Scooby-Doo - Thème par David Mook et Ben Raleigh",
+      "exorcist": "L'Exorciste - Tubular Bells par Mike Oldfield",
+      "ghostbusters": "SOS Fantômes - Thème de Ray Parker Jr.",
+      "jaws": "Les Dents de la Mer - Thème de John Williams",
+      "lionKing": "Le Roi Lion - 'Soyez Prêtes' par Elton John et Tim Rice",
+      "ratched": "Ratched - Musique de Mac Quayle",
+      "buffy": "Buffy contre les vampires - Thème par Nerf Herder",
+      "scream": "Scream - Musique de Marco Beltrami",
+      "strangerThings": "Stranger Things - Thème par Kyle Dixon et Michael Stein",
+      "littleMermaid": "La Petite Sirène - 'Pauvres âmes en perdition' par Alan Menken et Howard Ashman",
+      "thriller": "Thriller - Michael Jackson",
+      "walkingDead": "The Walking Dead - Thème de Bear McCreary",
+      "saw": "Saw - 'Hello Zepp' par Charlie Clouser",
+      "charmed": "Charmed - Thème par Love Spit Love",
+      "dexter": "Dexter - Thème par Rolfe Kent",
+      "thisIsHalloween": "This is Halloween - L'Étrange Noël de Monsieur Jack, musique de Danny Elfman",
+      "fairUse": "Ces extraits sont utilisés dans un cadre d'utilisation équitable (fair use) à des fins éducatives et non commerciales. En cas de demande de retrait par les ayants droit, les contenus concernés seront immédiatement supprimés."
+    },
+    "privacy": {
+      "title": "5. Protection des données personnelles (RGPD)",
+      "dataCollection": {
+        "title": "Collecte de données",
+        "content": "Ce site ne collecte actuellement aucune donnée personnelle. Aucun formulaire de contact n'est présent. Le seul moyen de communication est via l'adresse email affichée publiquement."
+      },
+      "cookies": {
+        "title": "Cookies",
+        "content": "Ce site n'utilise actuellement aucun cookie de suivi ou d'analyse. Seuls les cookies techniques strictement nécessaires au fonctionnement du site peuvent être utilisés."
+      },
+      "rights": {
+        "title": "Vos droits",
+        "content": "Conformément au Règlement Général sur la Protection des Données (RGPD) et à la loi Informatique et Libertés, vous disposez d'un droit d'accès, de rectification, de suppression et de portabilité de vos données. Pour exercer ces droits, contactez-nous par email."
+      }
+    },
+    "liability": {
+      "title": "6. Limitation de responsabilité",
+      "content": "L'éditeur s'efforce de maintenir les informations du site à jour et exactes, mais ne peut garantir l'exactitude, la précision ou l'exhaustivité des informations. L'éditeur ne pourra être tenu responsable des erreurs, omissions, ou résultats obtenus de l'utilisation de ces informations."
+    },
+    "externalLinks": {
+      "title": "7. Liens externes",
+      "content": "Ce site peut contenir des liens vers des sites externes. L'éditeur n'a aucun contrôle sur le contenu de ces sites et décline toute responsabilité quant à leur contenu ou leurs pratiques."
+    },
+    "applicableLaw": {
+      "title": "8. Droit applicable",
+      "content": "Les présentes mentions légales sont régies par le droit français. Tout litige relatif à l'utilisation de ce site sera soumis à la compétence exclusive des tribunaux français."
+    }
+  },
   "halloween": {
+    "credits_notice": "Les extraits musicaux sont utilisés à des fins éducatives et non commerciales. Voir les",
+    "credits_link": "crédits complets",
     "music": {
       "adams_family": "La famille Addams",
       "american_horror_story": "American Horror Story",

--- a/src/app/[locale]/(default)/halloween/ui/Halloween.spec.tsx
+++ b/src/app/[locale]/(default)/halloween/ui/Halloween.spec.tsx
@@ -4,7 +4,8 @@ import { Halloween } from './Halloween'
 
 // Mock des dépendances
 jest.mock('next-intl', () => ({
-  useTranslations: jest.fn()
+  useTranslations: jest.fn(),
+  useLocale: jest.fn(() => 'fr')
 }))
 
 jest.mock('@/src/components/CardHalloween/CardHalloween', () => ({

--- a/src/app/[locale]/(default)/halloween/ui/Halloween.tsx
+++ b/src/app/[locale]/(default)/halloween/ui/Halloween.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { useTranslations } from 'next-intl'
+import Link from 'next/link'
+import { useLocale, useTranslations } from 'next-intl'
 import React, { ReactElement, useState } from 'react'
 import styles from './halloween.module.scss'
 import { CardHalloween } from '@/src/components/CardHalloween/CardHalloween'
+import { Routes } from '@/types/routes'
 
 export default function Halloween(): ReactElement {
   const t = useTranslations()
+  const locale = useLocale()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isAnswerVisible, setIsAnswerVisible] = useState(false)
 
@@ -152,6 +155,14 @@ export default function Halloween(): ReactElement {
             {t('halloween.next_button')}
           </button>
         </div>
+      </div>
+      <div className={styles.credits_notice}>
+        <p>
+          {t('halloween.credits_notice')}{' '}
+          <Link href={`/${locale}${Routes.LEGAL_NOTICE}`} className={styles.credits_link}>
+            {t('halloween.credits_link')}
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/src/app/[locale]/(default)/halloween/ui/halloween.module.scss
+++ b/src/app/[locale]/(default)/halloween/ui/halloween.module.scss
@@ -46,3 +46,28 @@
     }
   }
 }
+
+.credits_notice {
+  text-align: center;
+  margin: 2rem auto;
+  padding: 1rem;
+  max-width: 800px;
+  font-size: 1rem;
+  color: #990000;
+
+  p {
+    margin: 0;
+  }
+
+  .credits_link {
+    color: #d4d925;
+    text-decoration: underline;
+    font-weight: bold;
+    cursor: pointer;
+    transition: color 0.3s ease;
+
+    &:hover {
+      color: #ffffff;
+    }
+  }
+}

--- a/src/app/[locale]/(legal)/mentions-legales/page.tsx
+++ b/src/app/[locale]/(legal)/mentions-legales/page.tsx
@@ -1,0 +1,10 @@
+import { ReactElement } from 'react'
+import MentionsLegales from './ui/MentionsLegales'
+
+export async function generateStaticParams() {
+  return [{ locale: 'fr' }, { locale: 'en' }]
+}
+
+export default function MentionsLegalesPage(): ReactElement {
+  return <MentionsLegales />
+}

--- a/src/app/[locale]/(legal)/mentions-legales/ui/MentionsLegales.tsx
+++ b/src/app/[locale]/(legal)/mentions-legales/ui/MentionsLegales.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useTranslations } from 'next-intl';
+import { ReactElement } from 'react';
+import styles from './mentionsLegales.module.scss';
+
+export default function MentionsLegales(): ReactElement {
+  const t = useTranslations('legalNotice')
+
+  return (
+    <div className={styles.legalNotice}>
+      <h1 className={styles.mainTitle}>{t('title')}</h1>
+      <p className={styles.lastUpdate}>{t('lastUpdate')}</p>
+
+      <section className={styles.section}>
+        <h2>{t('editor.title')}</h2>
+        <p>
+          <strong>{t('editor.name')}</strong> Marion Grolleau
+        </p>
+        <p>
+          <strong>{t('editor.address')}</strong> Saint-Maurice-De-Lignon
+        </p>
+        <p>
+          <strong>{t('editor.email')}</strong>{' '}
+          <a href="mailto:mariongrolleau62@gmail.com">mariongrolleau62@gmail.com</a>
+        </p>
+        <p>
+          <strong>{t('editor.siteType')}</strong> {t('editor.siteTypeValue')}
+        </p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('hosting.title')}</h2>
+        <p>
+          <strong>{t('hosting.provider')}</strong> Netlify, Inc.
+        </p>
+        <p>
+          <strong>{t('hosting.address')}</strong> 44 Montgomery Street, Suite 300, San Francisco, CA 94104, USA
+        </p>
+        <p>
+          <strong>{t('hosting.website')}</strong>{' '}
+          <a href="https://www.netlify.com" target="_blank" rel="noopener noreferrer">
+            www.netlify.com
+          </a>
+        </p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('intellectualProperty.title')}</h2>
+        <p>{t('intellectualProperty.content')}</p>
+        <p>{t('intellectualProperty.copyright')}</p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('musicCredits.title')}</h2>
+        <p>{t('musicCredits.intro')}</p>
+        <ul className={styles.creditsList}>
+          <li>{t('musicCredits.addamsFamily')}</li>
+          <li>{t('musicCredits.americanHorrorStory')}</li>
+          <li>{t('musicCredits.coraline')}</li>
+          <li>{t('musicCredits.corpseBride')}</li>
+          <li>{t('musicCredits.scoobyDoo')}</li>
+          <li>{t('musicCredits.exorcist')}</li>
+          <li>{t('musicCredits.ghostbusters')}</li>
+          <li>{t('musicCredits.jaws')}</li>
+          <li>{t('musicCredits.lionKing')}</li>
+          <li>{t('musicCredits.ratched')}</li>
+          <li>{t('musicCredits.buffy')}</li>
+          <li>{t('musicCredits.scream')}</li>
+          <li>{t('musicCredits.strangerThings')}</li>
+          <li>{t('musicCredits.littleMermaid')}</li>
+          <li>{t('musicCredits.thriller')}</li>
+          <li>{t('musicCredits.walkingDead')}</li>
+          <li>{t('musicCredits.saw')}</li>
+          <li>{t('musicCredits.charmed')}</li>
+          <li>{t('musicCredits.dexter')}</li>
+          <li>{t('musicCredits.thisIsHalloween')}</li>
+        </ul>
+        <p>{t('musicCredits.fairUse')}</p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('privacy.title')}</h2>
+        <h3>{t('privacy.dataCollection.title')}</h3>
+        <p>{t('privacy.dataCollection.content')}</p>
+
+        <h3>{t('privacy.cookies.title')}</h3>
+        <p>{t('privacy.cookies.content')}</p>
+
+        <h3>{t('privacy.rights.title')}</h3>
+        <p>{t('privacy.rights.content')}</p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('liability.title')}</h2>
+        <p>{t('liability.content')}</p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('externalLinks.title')}</h2>
+        <p>{t('externalLinks.content')}</p>
+      </section>
+
+      <section className={styles.section}>
+        <h2>{t('applicableLaw.title')}</h2>
+        <p>{t('applicableLaw.content')}</p>
+      </section>
+    </div>
+  )
+}
+
+export { MentionsLegales };

--- a/src/app/[locale]/(legal)/mentions-legales/ui/mentionsLegales.module.scss
+++ b/src/app/[locale]/(legal)/mentions-legales/ui/mentionsLegales.module.scss
@@ -1,0 +1,105 @@
+.legalNotice {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  line-height: 1.6;
+  color: var(--color-white);
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+}
+
+.mainTitle {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  background: linear-gradient(43deg, var(--color-violet) 0%, var(--color-pink) 46%, var(--color-yellow) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-align: center;
+
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+}
+
+.lastUpdate {
+  text-align: center;
+  font-style: italic;
+  color: var(--color-white);
+  opacity: 0.7;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border-left: 4px solid var(--color-violet);
+
+  h2 {
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+    color: var(--color-yellow);
+    border-bottom: 2px solid var(--color-violet);
+    padding-bottom: 0.5rem;
+
+    @media (max-width: 768px) {
+      font-size: 1.5rem;
+    }
+  }
+
+  h3 {
+    font-size: 1.3rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--color-pink);
+
+    @media (max-width: 768px) {
+      font-size: 1.2rem;
+    }
+  }
+
+  p {
+    margin-bottom: 1rem;
+    text-align: justify;
+
+    strong {
+      color: var(--color-yellow);
+      font-weight: 600;
+    }
+  }
+
+  a {
+    color: var(--color-violet);
+    text-decoration: none;
+    transition: color 0.3s ease;
+
+    &:hover {
+      color: var(--color-pink);
+      text-decoration: underline;
+    }
+  }
+}
+
+.creditsList {
+  list-style-type: none;
+  padding-left: 0;
+
+  li {
+    padding: 0.5rem 0;
+    padding-left: 1.5rem;
+    position: relative;
+
+    &::before {
+      content: '♪';
+      position: absolute;
+      left: 0;
+      color: var(--color-pink);
+      font-weight: bold;
+    }
+  }
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,8 +3,7 @@ import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
 import { ReactNode } from 'react'
 
-import { Footer } from '@/src/components/Footer/Footer'
-import { Header } from '@/src/components/Header/Header'
+import { LayoutContent } from '@/src/components/LayoutContent/LayoutContent'
 import './globals.scss'
 
 export const metadata: Metadata = {
@@ -38,9 +37,7 @@ export default async function LocaleLayout(props: Props) {
     <html lang={locale}>
       <body suppressHydrationWarning={true}>
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <Header />
-          {children}
-          <Footer />
+          <LayoutContent>{children}</LayoutContent>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/Footer/Footer.spec.tsx
+++ b/src/components/Footer/Footer.spec.tsx
@@ -4,7 +4,8 @@ import { Footer } from './Footer'
 
 // Mock des dépendances
 jest.mock('next-intl', () => ({
-  useTranslations: jest.fn()
+  useTranslations: jest.fn(),
+  useLocale: jest.fn(() => 'fr')
 }))
 
 jest.mock('react-icons/io5', () => ({

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,15 +1,21 @@
-import { useTranslations } from 'next-intl'
+import Link from 'next/link'
+import { useLocale, useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 import { IoMailOutline } from 'react-icons/io5'
 import packageJson from '../../../package.json'
 import styles from './footer.module.scss'
+import { Routes } from '@/types/routes'
 
 function Footer(): ReactElement {
   const currentYear = new Date().getFullYear()
   const t = useTranslations()
+  const locale = useLocale()
+
   return (
     <div className={styles.footer}>
-      <p className={styles.legalsMentions}>{t('footer.legal_notice')}</p>
+      <Link href={`/${locale}${Routes.LEGAL_NOTICE}`} className={styles.legalsMentions}>
+        {t('footer.legal_notice')}
+      </Link>
       <p className={styles.copyright}>{t('footer.copyright', { currentYear })}</p>
       <p className={styles.version}>v{packageJson.version}</p>
 

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -7,8 +7,28 @@
   margin: 5rem 0 0 0;
 }
 
+.legalsMentions {
+  color: white;
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
 .contact {
   padding-top: 0.3rem;
+  color: white;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
+.copyright {
+  margin: 0;
 }
 
 .version {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,7 +9,11 @@ import { Navigation } from '../Navigation/Navigation'
 import styles from './header.module.scss'
 import ChangeLogoWithDate from '@/src/utils/ChangeLogoWithDate'
 
-function Header(): ReactElement {
+type HeaderProps = {
+  hideNavigation?: boolean
+}
+
+function Header({ hideNavigation = false }: HeaderProps): ReactElement {
   const locale = useLocale()
 
   return (
@@ -17,24 +21,27 @@ function Header(): ReactElement {
       <Link id="header" href={`/${locale}`}>
         {ChangeLogoWithDate()}
       </Link>
-      {typeof window !== 'undefined' && window.innerWidth <= 768 ? <MenuBurger /> : <Navigation />}
-      <div>
-        <div className={styles.iconSocials}>
-          <a href="https://www.linkedin.com/in/mariongrolleau/" target="_blank" rel="noreferrer">
-            <Image
-              priority
-              className={styles.logoLinkedIn}
-              src={'/logoLinkedIn.png'}
-              alt="LinkedIn"
-              width={60}
-              height={60}
-            />
-          </a>
-          <a href="https://github.com/Mariion-62">
-            <Image src={'/logoGitHub.png'} alt="Github" className={styles.logoGitHub} width={60} height={60} />
-          </a>
+      {!hideNavigation &&
+        (typeof window !== 'undefined' && window.innerWidth <= 768 ? <MenuBurger /> : <Navigation />)}
+      {!hideNavigation && (
+        <div>
+          <div className={styles.iconSocials}>
+            <a href="https://www.linkedin.com/in/mariongrolleau/" target="_blank" rel="noreferrer">
+              <Image
+                priority
+                className={styles.logoLinkedIn}
+                src={'/logoLinkedIn.png'}
+                alt="LinkedIn"
+                width={60}
+                height={60}
+              />
+            </a>
+            <a href="https://github.com/Mariion-62">
+              <Image src={'/logoGitHub.png'} alt="Github" className={styles.logoGitHub} width={60} height={60} />
+            </a>
+          </div>
         </div>
-      </div>
+      )}
     </header>
   )
 }

--- a/src/components/LayoutContent/LayoutContent.tsx
+++ b/src/components/LayoutContent/LayoutContent.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { ReactElement, ReactNode } from 'react'
+import { Footer } from '@/src/components/Footer/Footer'
+import { Header } from '@/src/components/Header/Header'
+
+type Props = {
+  children: ReactNode
+}
+
+function LayoutContent({ children }: Props): ReactElement {
+  const pathname = usePathname()
+
+  // Vérifie si on est sur la page mentions légales
+  const isLegalPage = pathname.includes('/mentions-legales')
+
+  return (
+    <>
+      <Header hideNavigation={isLegalPage} />
+      {children}
+      <Footer />
+    </>
+  )
+}
+
+export { LayoutContent }

--- a/types/routes.ts
+++ b/types/routes.ts
@@ -1,5 +1,6 @@
 export enum Routes {
   HOME = '/',
   CAREERS = '/mon-parcours',
-  PROJECTS = '/mes-realisations'
+  PROJECTS = '/mes-realisations',
+  LEGAL_NOTICE = '/mentions-legales'
 }


### PR DESCRIPTION
- Add comprehensive legalNotice translations for en and fr
- Implement MentionsLegales UI, styles and page route
- Add Routes.LEGAL_NOTICE constant
- Introduce LayoutContent to compose Header/children/Footer and use it in locale layout
- Update Header to accept hideNavigation prop and hide navigation on legal page
- Link legal notices from Footer and Halloween credits (uses locale + route)
- Add styles for credits notice and legal page